### PR TITLE
Compilation fixes for MySQL 5.5

### DIFF
--- a/driver/connect.c
+++ b/driver/connect.c
@@ -513,10 +513,10 @@ SQLRETURN myodbc_do_connect(DBC *dbc, DataSource *ds)
   }
 
 #if MYSQL_VERSION_ID >= 50709
-  mysql_get_option(mysql, MYSQL_OPT_NET_BUFFER_LENGTH, &dbc->net_buffer_length);
+  mysql_get_option(mysql, MYSQL_OPT_NET_BUFFER_LENGTH, &dbc->net_buffer_len);
 #else
   // for older versions just use net_buffer_length() macro
-  dbc->net_buffer_length = net_buffer_length;
+  dbc->net_buffer_len = net_buffer_length;
 #endif
   return rc;
 

--- a/driver/connect.c
+++ b/driver/connect.c
@@ -245,12 +245,14 @@ SQLRETURN myodbc_do_connect(DBC *dbc, DataSource *ds)
     mysql_options(mysql, MYSQL_OPT_SSL_VERIFY_SERVER_CERT,
                   (const char *)&opt_ssl_verify_server_cert);
 
+#if MYSQL_VERSION_ID >= 50660
   if (ds->rsakey)
   {
     /* Read the public key on the client side */
     mysql_options(mysql, MYSQL_SERVER_PUBLIC_KEY,
                   ds_get_utf8attr(ds->rsakey, &ds->rsakey8));
   }
+#endif
 
 #if MYSQL_VERSION_ID >= 50710
   {

--- a/driver/cursor.c
+++ b/driver/cursor.c
@@ -1465,7 +1465,7 @@ static SQLRETURN batch_insert( STMT *stmt, SQLULEN irow, DYNAMIC_STRING *ext_que
               We have a limited capacity to shove data across the wire, but
               we handle this by sending in multiple calls to exec_stmt_query()
             */
-            if (ext_query->length + length >= (SQLULEN) stmt->dbc->net_buffer_length)
+            if (ext_query->length + length >= (SQLULEN) stmt->dbc->net_buffer_len)
             {
                 break_insert= TRUE;
                 break;

--- a/driver/driver.h
+++ b/driver/driver.h
@@ -378,7 +378,7 @@ typedef struct tagDBC
   int           txn_isolation;
   uint          port;
   uint          cursor_count;
-  ulong         net_buffer_length;
+  ulong         net_buffer_len;
   uint          commit_flag;
 #ifdef THREAD
   myodbc_mutex_t lock;

--- a/driver/info.c
+++ b/driver/info.c
@@ -587,7 +587,7 @@ MySQLGetInfo(SQLHDBC hdbc, SQLUSMALLINT fInfoType,
     MYINFO_SET_USHORT(0);
 
   case SQL_MAX_STATEMENT_LEN:
-    MYINFO_SET_ULONG(dbc->net_buffer_length);
+    MYINFO_SET_ULONG(dbc->net_buffer_len);
 
   case SQL_MAX_TABLE_NAME_LEN:
     MYINFO_SET_USHORT(NAME_LEN);

--- a/util/stringutil.c
+++ b/util/stringutil.c
@@ -983,3 +983,11 @@ SQLWCHAR *wchar_t_as_sqlwchar(wchar_t *from, SQLWCHAR *to, size_t len)
     return out;
   }
 }
+
+#if MYSQL_VERSION_ID < 50700
+char *my_stpmov(char *dst, const char *src)
+{
+      while ((*dst++ = *src++)) ;
+        return dst-1;
+}
+#endif

--- a/util/stringutil.h
+++ b/util/stringutil.h
@@ -120,6 +120,8 @@ SQLWCHAR *wchar_t_as_sqlwchar(wchar_t *from, SQLWCHAR *to, size_t len);
 char * myodbc_strlwr(char *target, size_t len);
 SQLCHAR* sqlwchar_as_utf8_simple(SQLWCHAR *s);
 
+char *my_stpmov(char *dst, const char *src);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
I wanted to have my own build of the connector for debugging purposes on a Debian Jessie system, which only comes with MySQL 5.5.55 headers and libraries, so I've applied a couple of fixes to make the latest version to compile with this older version of MySQL.

This shouldn't change anything with the latest MySQL, but I couldn't test it.