### PR TITLE
Fix compilation issues with 5.3.11

### DIFF
--- a/configure.cmake
+++ b/configure.cmake
@@ -396,6 +396,7 @@ CHECK_TYPE_SIZE("int"       SIZEOF_INT)
 CHECK_TYPE_SIZE("long long" SIZEOF_LONG_LONG)
 CHECK_TYPE_SIZE("off_t"     SIZEOF_OFF_T)
 CHECK_TYPE_SIZE("time_t"    SIZEOF_TIME_T)
+CHECK_TYPE_SIZE("struct timespec" STRUCT_TIMESPEC)
 
 # If finds the size of a type, set SIZEOF_<type> and HAVE_<type>
 FUNCTION(MY_CHECK_TYPE_SIZE type defbase)

--- a/driver/handle.cc
+++ b/driver/handle.cc
@@ -47,6 +47,10 @@
 
 #include "driver.h"
 
+extern void init_alloc_root(PSI_memory_key key,
+                            MEM_ROOT *mem_root, size_t block_size,
+                            size_t pre_alloc_size);
+
 #ifdef _UNIX_
 /* variables for thread counter */
 static myodbc_key_t myodbc_thread_counter_key;

--- a/driver/utility.cc
+++ b/driver/utility.cc
@@ -33,6 +33,7 @@
 
 #include "driver.h"
 #include "errmsg.h"
+#include "mysql/service_mysql_alloc.h"
 #include <ctype.h>
 
 

--- a/include/sys/my_base.h
+++ b/include/sys/my_base.h
@@ -25,6 +25,422 @@
 // You should have received a copy of the GNU General Public License 
 // along with this program; if not, write to the Free Software Foundation, Inc., 
 // 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA 
+
+
+/* This file includes constants used with all databases */
+
+#ifndef _my_base_h
+#define _my_base_h
+
+#include "my_global.h"
+
+/* The following is bits in the flag parameter to ha_open() */
+
+#define HA_OPEN_ABORT_IF_LOCKED		0	/* default */
+#define HA_OPEN_WAIT_IF_LOCKED		1
+#define HA_OPEN_IGNORE_IF_LOCKED	2
+#define HA_OPEN_TMP_TABLE		4	/* Table is a temp table */
+#define HA_OPEN_DELAY_KEY_WRITE		8	/* Don't update index  */
+#define HA_OPEN_ABORT_IF_CRASHED	16
+#define HA_OPEN_FOR_REPAIR		32	/* open even if crashed */
+#define HA_OPEN_FROM_SQL_LAYER          64
+#define HA_OPEN_MMAP                    128     /* open memory mapped */
+#define HA_OPEN_COPY			256     /* Open copy (for repair) */
+/* Internal temp table, used for temporary results */
+#define HA_OPEN_INTERNAL_TABLE          512
+/**
+  Don't connect any share_psi to the handler, since it is a partition.
+  It would not be used, since partitions don't call unbind_psi()/rebind_psi().
+*/
+#define HA_OPEN_NO_PSI_CALL             1024    /* Don't call/connect PSI */
+
+/* The following is parameter to ha_rkey() how to use key */
+
+/*
+  We define a complete-field prefix of a key value as a prefix where
+  the last included field in the prefix contains the full field, not
+  just some bytes from the start of the field. A partial-field prefix
+  is allowed to contain only a few first bytes from the last included
+  field.
+
+  Below HA_READ_KEY_EXACT, ..., HA_READ_BEFORE_KEY can take a
+  complete-field prefix of a key value as the search
+  key. HA_READ_PREFIX and HA_READ_PREFIX_LAST could also take a
+  partial-field prefix, but currently (4.0.10) they are only used with
+  complete-field prefixes. MySQL uses a padding trick to implement
+  LIKE 'abc%' queries.
+
+  NOTE that in InnoDB HA_READ_PREFIX_LAST will NOT work with a
+  partial-field prefix because InnoDB currently strips spaces from the
+  end of varchar fields!
+*/
+
+enum ha_rkey_function {
+  HA_READ_KEY_EXACT,              /* Find first record else error */
+  HA_READ_KEY_OR_NEXT,            /* Record or next record */
+  HA_READ_KEY_OR_PREV,            /* Record or previous */
+  HA_READ_AFTER_KEY,              /* Find next rec. after key-record */
+  HA_READ_BEFORE_KEY,             /* Find next rec. before key-record */
+  HA_READ_PREFIX,                 /* Key which as same prefix */
+  HA_READ_PREFIX_LAST,            /* Last key with the same prefix */
+  HA_READ_PREFIX_LAST_OR_PREV,    /* Last or prev key with the same prefix */
+  HA_READ_MBR_CONTAIN,            /* Minimum Bounding Rectangle contains */
+  HA_READ_MBR_INTERSECT,          /* Minimum Bounding Rectangle intersect */
+  HA_READ_MBR_WITHIN,             /* Minimum Bounding Rectangle within */
+  HA_READ_MBR_DISJOINT,           /* Minimum Bounding Rectangle disjoint */
+  HA_READ_MBR_EQUAL,              /* Minimum Bounding Rectangle equal */
+  HA_READ_INVALID= -1             /* Invalid enumeration value, always last. */
+};
+
+	/* Key algorithm types */
+
+enum ha_key_alg {
+  HA_KEY_ALG_UNDEF=	0,		/* Not specified (old file) */
+  HA_KEY_ALG_BTREE=	1,		/* B-tree, default one          */
+  HA_KEY_ALG_RTREE=	2,		/* R-tree, for spatial searches */
+  HA_KEY_ALG_HASH=	3,		/* HASH keys (HEAP tables) */
+  HA_KEY_ALG_FULLTEXT=	4		/* FULLTEXT (MyISAM tables) */
+};
+
+        /* Storage media types */ 
+
+enum ha_storage_media {
+  HA_SM_DEFAULT=        0,		/* Not specified (engine default) */
+  HA_SM_DISK=           1,		/* DISK storage */
+  HA_SM_MEMORY=         2		/* MAIN MEMORY storage */
+};
+
+	/* The following is parameter to ha_extra() */
+
+enum ha_extra_function {
+  HA_EXTRA_NORMAL=0,			/* Optimize for space (def) */
+  HA_EXTRA_QUICK=1,			/* Optimize for speed */
+  HA_EXTRA_NOT_USED=2,
+  HA_EXTRA_CACHE=3,			/* Cache record in HA_rrnd() */
+  HA_EXTRA_NO_CACHE=4,			/* End caching of records (def) */
+  HA_EXTRA_NO_READCHECK=5,		/* No readcheck on update */
+  HA_EXTRA_READCHECK=6,			/* Use readcheck (def) */
+  HA_EXTRA_KEYREAD=7,			/* Read only key to database */
+  HA_EXTRA_NO_KEYREAD=8,		/* Normal read of records (def) */
+  HA_EXTRA_NO_USER_CHANGE=9,		/* No user is allowed to write */
+  HA_EXTRA_KEY_CACHE=10,
+  HA_EXTRA_NO_KEY_CACHE=11,
+  HA_EXTRA_WAIT_LOCK=12,		/* Wait until file is avalably (def) */
+  HA_EXTRA_NO_WAIT_LOCK=13,		/* If file is locked, return quickly */
+  HA_EXTRA_WRITE_CACHE=14,		/* Use write cache in ha_write() */
+  HA_EXTRA_FLUSH_CACHE=15,		/* flush write_record_cache */
+  HA_EXTRA_NO_KEYS=16,			/* Remove all update of keys */
+  HA_EXTRA_KEYREAD_CHANGE_POS=17,	/* Keyread, but change pos */
+					/* xxxxchk -r must be used */
+  HA_EXTRA_REMEMBER_POS=18,		/* Remember pos for next/prev */
+  HA_EXTRA_RESTORE_POS=19,
+  HA_EXTRA_REINIT_CACHE=20,		/* init cache from current record */
+  HA_EXTRA_FORCE_REOPEN=21,		/* Datafile have changed on disk */
+  HA_EXTRA_FLUSH,			/* Flush tables to disk */
+  HA_EXTRA_NO_ROWS,			/* Don't write rows */
+  HA_EXTRA_RESET_STATE,			/* Reset positions */
+  HA_EXTRA_IGNORE_DUP_KEY,		/* Dup keys don't rollback everything*/
+  HA_EXTRA_NO_IGNORE_DUP_KEY,
+  HA_EXTRA_PREPARE_FOR_DROP,
+  HA_EXTRA_PREPARE_FOR_UPDATE,		/* Remove read cache if problems */
+  HA_EXTRA_PRELOAD_BUFFER_SIZE,         /* Set buffer size for preloading */
+  /*
+    On-the-fly switching between unique and non-unique key inserting.
+  */
+  HA_EXTRA_CHANGE_KEY_TO_UNIQUE,
+  HA_EXTRA_CHANGE_KEY_TO_DUP,
+  /*
+    When using HA_EXTRA_KEYREAD, overwrite only key member fields and keep 
+    other fields intact. When this is off (by default) InnoDB will use memcpy
+    to overwrite entire row.
+  */
+  HA_EXTRA_KEYREAD_PRESERVE_FIELDS,
+  HA_EXTRA_MMAP,
+  /*
+    Ignore if the a tuple is not found, continue processing the
+    transaction and ignore that 'row'.  Needed for idempotency
+    handling on the slave
+
+    Currently only used by NDB storage engine. Partition handler ignores flag.
+  */
+  HA_EXTRA_IGNORE_NO_KEY,
+  HA_EXTRA_NO_IGNORE_NO_KEY,
+  /*
+    Mark the table as a log table. For some handlers (e.g. CSV) this results
+    in a special locking for the table.
+  */
+  HA_EXTRA_MARK_AS_LOG_TABLE,
+  /*
+    Informs handler that write_row() which tries to insert new row into the
+    table and encounters some already existing row with same primary/unique
+    key can replace old row with new row instead of reporting error (basically
+    it informs handler that we do REPLACE instead of simple INSERT).
+    Off by default.
+  */
+  HA_EXTRA_WRITE_CAN_REPLACE,
+  HA_EXTRA_WRITE_CANNOT_REPLACE,
+  /*
+    Inform handler that delete_row()/update_row() cannot batch deletes/updates
+    and should perform them immediately. This may be needed when table has 
+    AFTER DELETE/UPDATE triggers which access to subject table.
+    These flags are reset by the handler::extra(HA_EXTRA_RESET) call.
+  */
+  HA_EXTRA_DELETE_CANNOT_BATCH,
+  HA_EXTRA_UPDATE_CANNOT_BATCH,
+  /*
+    Inform handler that an "INSERT...ON DUPLICATE KEY UPDATE" will be
+    executed. This condition is unset by HA_EXTRA_NO_IGNORE_DUP_KEY.
+  */
+  HA_EXTRA_INSERT_WITH_UPDATE,
+  /* Inform handler that we will do a rename */
+  HA_EXTRA_PREPARE_FOR_RENAME,
+  /*
+    Special actions for MERGE tables.
+  */
+  HA_EXTRA_ADD_CHILDREN_LIST,
+  HA_EXTRA_ATTACH_CHILDREN,
+  HA_EXTRA_IS_ATTACHED_CHILDREN,
+  HA_EXTRA_DETACH_CHILDREN,
+  /*
+    Prepare table for export
+    (e.g. quiesce the table and write table metadata).
+  */
+  HA_EXTRA_EXPORT,
+  /** Do secondary sort by handler::ref (rowid) after key sort. */
+  HA_EXTRA_SECONDARY_SORT_ROWID
+};
+
+/* Compatible option, to be deleted in 6.0 */
+#define HA_EXTRA_PREPARE_FOR_DELETE HA_EXTRA_PREPARE_FOR_DROP
+
+	/* The following is parameter to ha_panic() */
+
+enum ha_panic_function {
+  HA_PANIC_CLOSE,			/* Close all databases */
+  HA_PANIC_WRITE,			/* Unlock and write status */
+  HA_PANIC_READ				/* Lock and read keyinfo */
+};
+
+	/* The following is parameter to ha_create(); keytypes */
+
+enum ha_base_keytype {
+  HA_KEYTYPE_END=0,
+  HA_KEYTYPE_TEXT=1,			/* Key is sorted as letters */
+  HA_KEYTYPE_BINARY=2,			/* Key is sorted as unsigned chars */
+  HA_KEYTYPE_SHORT_INT=3,
+  HA_KEYTYPE_LONG_INT=4,
+  HA_KEYTYPE_FLOAT=5,
+  HA_KEYTYPE_DOUBLE=6,
+  HA_KEYTYPE_NUM=7,			/* Not packed num with pre-space */
+  HA_KEYTYPE_USHORT_INT=8,
+  HA_KEYTYPE_ULONG_INT=9,
+  HA_KEYTYPE_LONGLONG=10,
+  HA_KEYTYPE_ULONGLONG=11,
+  HA_KEYTYPE_INT24=12,
+  HA_KEYTYPE_UINT24=13,
+  HA_KEYTYPE_INT8=14,
+  /* Varchar (0-255 bytes) with length packed with 1 byte */
+  HA_KEYTYPE_VARTEXT1=15,               /* Key is sorted as letters */
+  HA_KEYTYPE_VARBINARY1=16,             /* Key is sorted as unsigned chars */
+  /* Varchar (0-65535 bytes) with length packed with 2 bytes */
+  HA_KEYTYPE_VARTEXT2=17,		/* Key is sorted as letters */
+  HA_KEYTYPE_VARBINARY2=18,		/* Key is sorted as unsigned chars */
+  HA_KEYTYPE_BIT=19
+};
+
+#define HA_MAX_KEYTYPE	31		/* Must be log2-1 */
+
+	/* These flags kan be OR:ed to key-flag */
+
+#define HA_NOSAME		 1	/* Set if not dupplicated records */
+#define HA_PACK_KEY		 2	/* Pack string key to previous key */
+#define HA_AUTO_KEY		 16
+#define HA_BINARY_PACK_KEY	 32	/* Packing of all keys to prev key */
+#define HA_FULLTEXT		128     /* For full-text search */
+#define HA_UNIQUE_CHECK		256	/* Check the key for uniqueness */
+#define HA_SPATIAL		1024    /* For spatial search */
+#define HA_NULL_ARE_EQUAL	2048	/* NULL in key are cmp as equal */
+#define HA_GENERATED_KEY	8192	/* Automaticly generated key */
+
+        /* The combination of the above can be used for key type comparison. */
+#define HA_KEYFLAG_MASK (HA_NOSAME | HA_PACK_KEY | HA_AUTO_KEY | \
+                         HA_BINARY_PACK_KEY | HA_FULLTEXT | HA_UNIQUE_CHECK | \
+                         HA_SPATIAL | HA_NULL_ARE_EQUAL | HA_GENERATED_KEY)
+
+/*
+  Key contains partial segments.
+
+  This flag is internal to the MySQL server by design. It is not supposed
+  neither to be saved in FRM-files, nor to be passed to storage engines.
+  It is intended to pass information into internal static sort_keys(KEY *,
+  KEY *) function.
+
+  This flag can be calculated -- it's based on key lengths comparison.
+*/
+#define HA_KEY_HAS_PART_KEY_SEG 65536
+/**
+  Key was renamed (or is result of renaming a key).
+
+  This is another flag internal to SQL-layer.
+  Used by in-place ALTER TABLE implementation.
+
+  @note This flag can be set for keys which have other changes than
+        simple renaming as well. So from the point of view of storage
+        engine such key might have to be dropped and re-created with
+        new definition.
+*/
+#define HA_KEY_RENAMED          (1 << 17)
+/** Set if a key is on any virtual generated columns */
+#define HA_VIRTUAL_GEN_KEY      (1 << 18)
+
+	/* Automatic bits in key-flag */
+
+#define HA_SPACE_PACK_USED	 4	/* Test for if SPACE_PACK used */
+#define HA_VAR_LENGTH_KEY	 8
+#define HA_NULL_PART_KEY	 64
+#define HA_USES_COMMENT          4096
+#define HA_USES_PARSER           16384  /* Fulltext index uses [pre]parser */
+#define HA_USES_BLOCK_SIZE	 ((uint) 32768)
+#define HA_SORT_ALLOWS_SAME      512    /* Intern bit when sorting records */
+
+	/* These flags can be added to key-seg-flag */
+
+#define HA_SPACE_PACK		 1	/* Pack space in key-seg */
+#define HA_PART_KEY_SEG		 4	/* Used by MySQL for part-key-cols */
+#define HA_VAR_LENGTH_PART	 8
+#define HA_NULL_PART		 16
+#define HA_BLOB_PART		 32
+#define HA_SWAP_KEY		 64
+#define HA_REVERSE_SORT		 128	/* Sort key in reverse order */
+#define HA_NO_SORT               256 /* do not bother sorting on this keyseg */
+/*
+  End space in unique/varchar are considered equal. (Like 'a' and 'a ')
+  Only needed for internal temporary tables.
+*/
+#define HA_END_SPACE_ARE_EQUAL	 512
+#define HA_BIT_PART		1024
+
+	/* optionbits for database */
+#define HA_OPTION_PACK_RECORD		1
+#define HA_OPTION_PACK_KEYS		2
+#define HA_OPTION_COMPRESS_RECORD	4
+#define HA_OPTION_LONG_BLOB_PTR		8 /* new ISAM format */
+#define HA_OPTION_TMP_TABLE		16
+#define HA_OPTION_CHECKSUM		32
+#define HA_OPTION_DELAY_KEY_WRITE	64
+#define HA_OPTION_NO_PACK_KEYS		128  /* Reserved for MySQL */
+#define HA_OPTION_CREATE_FROM_ENGINE    256
+#define HA_OPTION_RELIES_ON_SQL_LAYER   512
+#define HA_OPTION_NULL_FIELDS		1024
+#define HA_OPTION_PAGE_CHECKSUM		2048
+/** STATS_PERSISTENT=1 has been specified in the SQL command (either CREATE
+or ALTER TABLE). Table and index statistics that are collected by the
+storage engine and used by the optimizer for query optimization will be
+stored on disk and will not change after a server restart. */
+#define HA_OPTION_STATS_PERSISTENT	4096
+/** STATS_PERSISTENT=0 has been specified in CREATE/ALTER TABLE. Statistics
+for the table will be wiped away on server shutdown and new ones recalculated
+after the server is started again. If none of HA_OPTION_STATS_PERSISTENT or
+HA_OPTION_NO_STATS_PERSISTENT is set, this means that the setting is not
+explicitly set at table level and the corresponding table will use whatever
+is the global server default. */
+#define HA_OPTION_NO_STATS_PERSISTENT	8192
+#define HA_OPTION_TEMP_COMPRESS_RECORD	((uint) 16384)	/* set by isamchk */
+#define HA_OPTION_READ_ONLY_DATA	((uint) 32768)	/* Set by isamchk */
+
+	/* Bits in flag to create() */
+
+#define HA_DONT_TOUCH_DATA	1	/* Don't empty datafile (isamchk) */
+#define HA_PACK_RECORD		2	/* Request packed record format */
+#define HA_CREATE_TMP_TABLE	4
+#define HA_CREATE_CHECKSUM	8
+#define HA_CREATE_KEEP_FILES	16      /* don't overwrite .MYD and MYI */
+#define HA_CREATE_PAGE_CHECKSUM	32
+#define HA_CREATE_DELAY_KEY_WRITE 64
+#define HA_CREATE_RELIES_ON_SQL_LAYER 128
+#define HA_CREATE_INTERNAL_TABLE 256
+
+/*
+  The following flags (OR-ed) are passed to handler::info() method.
+  The method copies misc handler information out of the storage engine
+  to data structures accessible from MySQL
+
+  Same flags are also passed down to mi_status, myrg_status, etc.
+*/
+
+/* this one is not used */
+#define HA_STATUS_POS            1
+/*
+  assuming the table keeps shared actual copy of the 'info' and
+  local, possibly outdated copy, the following flag means that
+  it should not try to get the actual data (locking the shared structure)
+  slightly outdated version will suffice
+*/
+#define HA_STATUS_NO_LOCK        2
+/* update the time of the last modification (in handler::update_time) */
+#define HA_STATUS_TIME           4
+/*
+  update the 'constant' part of the info:
+  handler::max_data_file_length, max_index_file_length, create_time
+  sortkey, ref_length, block_size, data_file_name, index_file_name.
+  handler::table->s->keys_in_use, keys_for_keyread, rec_per_key
+*/
+#define HA_STATUS_CONST          8
+/*
+  update the 'variable' part of the info:
+  handler::records, deleted, data_file_length, index_file_length,
+  check_time, mean_rec_length
+*/
+#define HA_STATUS_VARIABLE      16
+/*
+  get the information about the key that caused last duplicate value error
+  update handler::errkey and handler::dupp_ref
+  see handler::get_dup_key()
+*/
+#define HA_STATUS_ERRKEY        32
+/*
+  update handler::auto_increment_value
+*/
+#define HA_STATUS_AUTO          64
+/*
+  Get also delete_length when HA_STATUS_VARIABLE is called. It's ok to set it also
+  when only HA_STATUS_VARIABLE but it won't be used.
+*/
+#define HA_STATUS_VARIABLE_EXTRA 128
+
+/*
+  Errorcodes given by handler functions
+
+  opt_sum_query() assumes these codes are > 1
+  Do not add error numbers before HA_ERR_FIRST.
+  If necessary to add lower numbers, change HA_ERR_FIRST accordingly.
+*/
+#define HA_ERR_FIRST            120	/* Copy of first error nr.*/
+
+#define HA_ERR_KEY_NOT_FOUND	120	/* Didn't find key on read or update */
+#define HA_ERR_FOUND_DUPP_KEY	121	/* Dupplicate key on write */
+#define HA_ERR_INTERNAL_ERROR   122	/* Internal error */
+#define HA_ERR_RECORD_CHANGED	123	/* Uppdate with is recoverable */
+#define HA_ERR_WRONG_INDEX	124	/* Wrong index given to function */
+#define HA_ERR_CRASHED		126	/* Indexfile is crashed */
+#define HA_ERR_WRONG_IN_RECORD	127	/* Record-file is crashed */
+#define HA_ERR_OUT_OF_MEM	128	/* Record-file is crashed */
+#define HA_ERR_NOT_A_TABLE      130     /* not a MYI file - no signature */
+#define HA_ERR_WRONG_COMMAND	131	/* Command not supported */
+#define HA_ERR_OLD_FILE		132	/* old databasfile */
+#define HA_ERR_NO_ACTIVE_RECORD 133	/* No record read in update() */
+#define HA_ERR_RECORD_DELETED	134	/* A record is not there */
+#define HA_ERR_RECORD_FILE_FULL 135	/* No more room in file */
+#define HA_ERR_INDEX_FILE_FULL	136	/* No more room in file */
+#define HA_ERR_END_OF_FILE	137	/* end in next/prev/first/last */
+#define HA_ERR_UNSUPPORTED	138	/* unsupported extension used */
+#define HA_ERR_TOO_BIG_ROW	139	/* Too big row */
+#define HA_WRONG_CREATE_OPTION	140	/* Wrong create option */
+#define HA_ERR_FOUND_DUPP_UNIQUE 141	/* Dupplicate unique on write */
+#define HA_ERR_UNKNOWN_CHARSET	 142	/* Can't open charset */
+#define HA_ERR_WRONG_MRG_TABLE_DEF 143	/* conflicting tables in MERGE */
+#define HA_ERR_CRASHED_ON_REPAIR 144	/* Last (automatic?) repair failed */
+#define HA_ERR_CRASHED_ON_USAGE  145	/* Table must be repaired */
 #define HA_ERR_LOCK_WAIT_TIMEOUT 146
 #define HA_ERR_LOCK_TABLE_FULL   147
 #define HA_ERR_READ_ONLY_TRANSACTION 148 /* Updates not allowed */


### PR DESCRIPTION
This patch includes the following modifications to fix compilation of MySQL Workbench 5.3.11 on Slackware Linux:
* configure.cmake - restore check for struct timespec
* driver/handle.cc - add prototype for init_alloc_root (do not know or cannot find the right header to use)
* driver/utility.cc - include mysql/service_mysql_alloc.h for my_free
* include/sys/my_base.h - restore contents from before revision 434d1b73210fb830c0b34f11f85a91f1cd391ba9