### PR TITLE
properly return SQL_SUCCESS_WITH_INFO

### DIFF
--- a/driver/utility.cc
+++ b/driver/utility.cc
@@ -1029,7 +1029,7 @@ SQLRETURN copy_binhex_result(STMT *stmt,
         }
         *dst= 0;
     }
-    if ( (ulong) cbValueMax > length*2 )
+    if ( length == src_length )
         return SQL_SUCCESS;
 
     stmt->set_error("01004", NULL, 0);


### PR DESCRIPTION
See detailed discussion on https://bugzilla.redhat.com/1947353 with reproducer


`    length= cbValueMax ? (ulong)(cbValueMax-1)/2 : 0;`

examples, 
*  even:   cbValueMax = 256 => length = 127
*  odd:    cbValueMax = 255 => length = 127

`    if ( (ulong) cbValueMax > length*2 )`

This is always true (256 or 255 > 254)


So, seems a better test.

`    if ( length == src_length )`


