### PR TITLE
Don't call freelocale with NULL.

### DIFF
--- a/driver/driver.h
+++ b/driver/driver.h
@@ -235,7 +235,10 @@ typedef enum { DESC_HDR, DESC_REC } fld_loc;
   #define __LOCALE_RESTORE() \
     { \
       uselocale(LC_GLOBAL_LOCALE); \
-      freelocale(nloc); \
+      if (nloc != NULL) \
+      { \
+        freelocale(nloc); \
+      } \
     }
 #else
 


### PR DESCRIPTION
If the call in  [driver.h#L243](https://github.com/mysql/mysql-connector-odbc/blob/master/driver/driver.h#L243) fails, `nloc` is assigned `(locale_t)0`.

The call to `uselocale` in [driver.h#L244](https://github.com/mysql/mysql-connector-odbc/blob/master/driver/driver.h#L244) with a `(locale_t)0` argument will result in the calling thread's current locale being left unchanged.

Although, the call to `freelocale` in [driver.h#L250](https://github.com/mysql/mysql-connector-odbc/blob/master/driver/driver.h#L250) with `(locale_t)0`, an invalid handle, is documented as undefined behavior and results in a segfault.

The below PoC demonstrates the resultant segfault when the `glibc-langpack-en` package is not installed on the CentOS 8 base docker image:

```c
#include <locale.h>
#include <assert.h>
int main(void) {
    locale_t l = newlocale(LC_CTYPE_MASK, "", (locale_t)0);
    assert(l == NULL);  // l should be NULL when glibc-langpack-en is not installed
    (void)freelocale(l);  // segfault
    return 0;
}
```

