### PR TITLE
Failed to get mysql version when using FindMySQL.cmake under MSVC

### DIFF
--- a/cmake/FindMySQL.cmake
+++ b/cmake/FindMySQL.cmake
@@ -788,10 +788,15 @@ if(MYSQL_INCLUDE_DIR AND NOT MYSQL_VERSION)
   # Write the C source file that will include the MySQL headers
   set(GETMYSQLVERSION_SOURCEFILE "${CMAKE_CURRENT_BINARY_DIR}/getmysqlversion.c")
   file(WRITE "${GETMYSQLVERSION_SOURCEFILE}"
+       "#ifdef WIN32\n"
+       "#include <winsock2.h>\n"
+       "#pragma comment(lib,\"Ws2_32.lib\")\n"
+       "#endif\n"
        "#include <mysql.h>\n"
        "#include <stdio.h>\n"
        "int main() {\n"
        "  printf(\"%s\", MYSQL_SERVER_VERSION);\n"
+       "  return 0;\n"
        "}\n"
   )
 


### PR DESCRIPTION
Maybe there was no problem with this file in this project, when I integrated `cmake/FindMySQL.cmake` into my own project and generate the VS2017 project under windows, an error occurs. there was a problem that the mysql version could not be obtained. This patch can be used to successfully compile getmysqlversion.c using MSVC under windows.

ps: Unfortunately, the Kitware does not provide officly find module for find the mysql