### PR TITLE
Update FindMySQL.cmake,fix bug on Windows

### DIFF
--- a/cmake/FindMySQL.cmake
+++ b/cmake/FindMySQL.cmake
@@ -788,7 +788,7 @@ if(MYSQL_INCLUDE_DIR AND NOT MYSQL_VERSION)
   # Write the C source file that will include the MySQL headers
   set(GETMYSQLVERSION_SOURCEFILE "${CMAKE_CURRENT_BINARY_DIR}/getmysqlversion.c")
   file(WRITE "${GETMYSQLVERSION_SOURCEFILE}"
-       "#include <mysql.h>\n"
+       "#include <mysql_version.h>\n"
        "#include <stdio.h>\n"
        "int main() {\n"
        "  printf(\"%s\", MYSQL_SERVER_VERSION);\n"


### PR DESCRIPTION
FIX BUG:Could not determine the MySQL Server version on Windows(5.6.37) Visual Studio 2015
caused by failt to compile getmysqlversion.c.change to  #include <mysql_version.h>,error cleaned.
==getmysqlversion.c
----------------------
#include <mysql.h>
#include <stdio.h>
int main() {
  printf("%s", MYSQL_SERVER_VERSION);
}
-------------------


cmake output:
-- Searching for static libraries with the base name(s) "mysqlclient"
DBG: User gave MYSQL_DIR = "D:/mysql-5.6.37-winx64"
DBG: Using MYSQL_DIR without "mysql_config" to find "mysql.h"
DBG: MYSQL_INCLUDE_DIR = "D:/mysql-5.6.37-winx64/include"
DBG: Using find_library() searching MYSQL_DIR and "lib/vs14 libmysql/Release client/Release libmysql_r/.libs libmysql/.libs libmysql lib/mysql lib/opt lib"
_lib         "D:/mysql-5.6.37-winx64/lib/mysqlclient.lib"
_lib_dir     "D:/mysql-5.6.37-winx64"
_lib_var     "MYSQL_LIB"
_lib_dir_var "MYSQL_DIR"
DBG: Could not compile "getmysqlversion.c"
CMake Error at cmake/Modules/FindMySQL.cmake:824 (message):
  Could not determine the MySQL Server version