### PR TITLE
Add additional #include directives in tests

### DIFF
--- a/dltest/dltest.c
+++ b/dltest/dltest.c
@@ -28,6 +28,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
 #ifdef WIN32
     #include <windows.h>

--- a/test/odbctap.h
+++ b/test/odbctap.h
@@ -78,6 +78,7 @@
 
 /* Get routines for helping with Unicode conversion. */
 #define ODBCTAP
+#include <wchar.h>
 
 #include "mysql_version.h"
 #include "../util/unicode_transcode.h"


### PR DESCRIPTION
Include <string.h> for the strncmp function, and <wchar.h> for wcscpy, wcslen and related functions.  This improves C99 compatibility because it avoids implicit function declarations.  Without these changes, compilation errors with future compilers are expected.

Related to:

* https://fedoraproject.org/wiki/Changes/PortingToModernC
* https://fedoraproject.org/wiki/Toolchain/PortingToModernC
