### PR TITLE
handle error during charset retrieval in windows setup gui

### DIFF
--- a/setupgui/windows/odbcdialogparams.cpp
+++ b/setupgui/windows/odbcdialogparams.cpp
@@ -604,7 +604,13 @@ void processCharsetCombobox(HWND hwnd, HWND hwndCtl, UINT codeNotify)
     case(CBN_DROPDOWN):
     {
       //FillParameters(hwnd, *pParams);
-      auto csl = mygetcharsets(hwnd, pParams);
+      std::vector<SQLWSTRING> csl;
+      try
+      {
+        csl = mygetcharsets(hwnd, pParams);
+      }
+      catch (MYERROR &e) {
+      }
 
       ComboBox_ResetContent(hwndCtl);
 


### PR DESCRIPTION
Similar try/catchsexists in the windows gui when calling `mygetdatabases`, 
In the gtk gui both  `mygetdatabases` `mygetcharsets` are contained in try/catch blocks