### PR TITLE
cmake: handle multiple MYSQL_INCLUDE_DIR

### DIFF
--- a/cmake/FindMySQL.cmake
+++ b/cmake/FindMySQL.cmake
@@ -534,6 +534,10 @@ elseif(MYSQL_CONFIG_EXECUTABLE)
                         "\"${MYSQL_CONFIG_EXECUTABLE}\"")
   endif()
 
+  # If there are multiple INCLUDE_DIR, 
+  # even a single INCLUDE_DIR will work
+  list(GET MYSQL_INCLUDE_DIR 0 MYSQL_INCLUDE_DIR)
+
   if(NOT EXISTS "${MYSQL_INCLUDE_DIR}/mysql.h")
     message(FATAL_ERROR "Could not find \"mysql.h\" in \"${MYSQL_INCLUDE_DIR}\" "
                         "found from running \"${MYSQL_CONFIG_EXECUTABLE}\"")


### PR DESCRIPTION
Hello 😊

I am trying to use the file `FindMySQL.cmake` in **Alpine**, and with only the system package manager, `MYSQL_INCLUDE_DIR` will be a list.

![image](https://github.com/mysql/mysql-connector-odbc/assets/40531369/ef692d59-e279-46c6-9b8e-5969c7fbdc97)

However, it is clear that the script does not handle the presence of multiple directories, and an error will occur.

> Could not find "mysql.h" in "/usr/include/mysql;/usr/include/mysql/mysql"

https://github.com/mysql/mysql-connector-odbc/blob/6a74b1cf45af8c728c89ed72fc803f6a2e555c31/cmake/FindMySQL.cmake#L529-L540

Just treat `MYSQL_INCLUDE_DIR` as a list and get its first element before calling `EXISTS` and it will work as expected. Even if `MYSQL_INCLUDE_DIR` is not a list, it will still work.

I think my patch would be a more compatible interim approach.