### PR TITLE
fix: dynamic sized key-value pair

### DIFF
--- a/setupgui/setupgui.h
+++ b/setupgui/setupgui.h
@@ -147,10 +147,12 @@ void setControlEnabled(unsigned int framenum, int idc, my_bool state);
 #define GET_STRING(name) \
   {                                                                \
     SQLWCHAR *res = getStrFieldData(hwnd, IDC_EDIT_##name);        \
-    if (res && *res)                                               \
+    if (res && *res) {                                             \
       params->opt_##name = res;                                    \
+      free(res);                                                   \
+    }                                                              \
     else                                                           \
-      params->opt_##name.set_default(nullptr);                    \
+      params->opt_##name.set_default(nullptr);                     \
   }
 
 #define GET_STRING_TAB(framenum, name) \
@@ -253,6 +255,7 @@ void setUnsignedFieldData(gchar *widget_name, unsigned int param);
     SQLWCHAR *res = getStrFieldData((gchar*)#name);                 \
     if (res && *res)                                               \
       params->opt_##name = res;                                    \
+      free(res);                                                   \
     else                                                           \
       params->opt_##name.set_default(nullptr);                     \
   }

--- a/setupgui/windows/odbcdialogparams.cpp
+++ b/setupgui/windows/odbcdialogparams.cpp
@@ -187,8 +187,9 @@ SQLWCHAR * getStrFieldData(HWND hwnd, int idc)
   int len = Edit_GetTextLength(GetDlgItem(hwnd,idc));
   if (len > 0)
   {
-    Edit_GetText(GetDlgItem(hwnd, idc), out_buf, len + 1);
-    return out_buf;
+    SQLWCHAR* buff = new SQLWCHAR[len + 1];
+    Edit_GetText(GetDlgItem(hwnd, idc), buff, len + 1);
+    return buff;
   }
   return nullptr;
 }

--- a/util/installer.cc
+++ b/util/installer.cc
@@ -637,7 +637,7 @@ int Driver::to_kvpair_null(SQLWCHAR *attrs, size_t attrslen)
  */
 void optionStr::set_remove_brackets(const SQLWCHAR *val_char,
                                     SQLINTEGER len) {
-  SQLWCHAR out[1024] = { 0 };
+  SQLWSTRING out;
 
   if (!val_char) {
     set_null();
@@ -651,26 +651,23 @@ void optionStr::set_remove_brackets(const SQLWCHAR *val_char,
   if (charcount)
   {
     const SQLWCHAR *val = val_str.c_str();
-    SQLWCHAR *pos = out;
     while (charcount)
     {
-      *pos = *val;
+      out += *val;
       if (charcount > 1 && ((*val == '}' && *(val + 1) == '}')))
       {
         ++val;
         --charcount;
       }
 
-      ++pos;
       ++val;
       --charcount;
     }
-    *pos = 0; // Terminate the string
   }
 
   m_wstr = out;
   // Re-use existing buffer, just as another type
-  SQLCHAR *c_out = reinterpret_cast<SQLCHAR *>(out);
+  SQLCHAR *c_out = reinterpret_cast<SQLCHAR *>(const_cast<wchar_t *>(out.c_str()));
   len = (SQLINTEGER)val_str.length();
   char *result = (char *)sqlwchar_as_utf8_ext(m_wstr.c_str(), &len,
     c_out, sizeof(out), nullptr);


### PR DESCRIPTION
## Summary
Fixes buffer Overflow for Large Connection String Key Values

## Description
- Changes the allocation from stack to heap for parsing in values into the DataSource
- Also includes changes for allowing larger values to be read from the ODBC Data Source GUI
- Prior to changes, key-value pairs which contain values with length over 1024 will crash the application on a buffer overflow.


https://bugs.mysql.com/bug.php?id=119511